### PR TITLE
Make HTTP return codes on error customizable (Issue #11)

### DIFF
--- a/Plugin/PersistedQueryPlugin.php
+++ b/Plugin/PersistedQueryPlugin.php
@@ -72,9 +72,10 @@ class PersistedQueryPlugin
 
         if ($persistedQueryHash && hash('sha256', $data['query']) !== $persistedQueryHash) {
             $result->setHttpResponseCode($request->isPost()
-                ? $this->scopeConfig->getValue('apq/general/invalid_sha_http_code_post', ScopeInterface::SCOPE_STORES) ?? 500
-                : $this->scopeConfig->getValue('apq/general/invalid_sha_http_code_get', ScopeInterface::SCOPE_STORES) ?? 400
-            );
+                ? $this->scopeConfig->getValue('apq/general/invalid_sha_http_code_post', ScopeInterface::SCOPE_STORES)
+                    ?? 500
+                : $this->scopeConfig->getValue('apq/general/invalid_sha_http_code_get', ScopeInterface::SCOPE_STORES)
+                    ?? 400);
             $result->setBody('provided sha does not match query');
             return $result;
         }
@@ -95,9 +96,10 @@ class PersistedQueryPlugin
 
         // apollo-server responds with 400 for GET and 500 for POST when no query is found
         $jsonResult->setHttpResponseCode($request->isPost()
-            ? $this->scopeConfig->getValue('apq/general/query_not_found_http_code_post', ScopeInterface::SCOPE_STORES) ?? 500
-            : $this->scopeConfig->getValue('apq/general/query_not_found_http_code_get', ScopeInterface::SCOPE_STORES) ?? 400
-        );
+            ? $this->scopeConfig->getValue('apq/general/query_not_found_http_code_post', ScopeInterface::SCOPE_STORES)
+            ?? 500
+            : $this->scopeConfig->getValue('apq/general/query_not_found_http_code_get', ScopeInterface::SCOPE_STORES)
+            ?? 400);
         $jsonResult->setData([
             'errors' => [
                 [

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Config:etc/system_file.xsd">
+    <system>
+        <section id="apq" translate="label" type="text" sortOrder="9000" showInDefault="1" showInWebsite="1" showInStore="1">
+            <label>Automatic Persisted Queries</label>
+            <tab>general</tab>
+            <resource>Danslo_Apq::config_apq</resource>
+            <group id="general" translate="label" type="text" sortOrder="10" showInDefault="1" showInWebsite="1" showInStore="1">
+                <label>General</label>
+                <field id="query_not_found_http_code_get" translate="label" type="text" sortOrder="10" showInDefault="1" showInWebsite="1" showInStore="1">
+                    <label>HTTP Return code on query not found (GET)</label>
+                    <comment>Default is 400</comment>
+                </field>
+                <field id="query_not_found_http_code_post" translate="label" type="text" sortOrder="20" showInDefault="1" showInWebsite="1" showInStore="1">
+                    <label>HTTP Return code on query not found (POST)</label>
+                    <comment>Default is 500</comment>
+                </field>
+
+                <field id="invalid_sha_http_code_get" translate="label" type="text" sortOrder="110" showInDefault="1" showInWebsite="1" showInStore="1">
+                    <label>HTTP Return code on invalid SHA (GET)</label>
+                    <comment>Default is 400</comment>
+                </field>
+                <field id="invalid_sha_http_code_post" translate="label" type="text" sortOrder="120" showInDefault="1" showInWebsite="1" showInStore="1">
+                    <label>HTTP Return code on invalid SHA (POST)</label>
+                    <comment>Default is 500</comment>
+                </field>
+            </group>
+        </section>
+    </system>
+</config>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -1,0 +1,12 @@
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Store:etc/config.xsd">
+    <default>
+        <apq>
+            <general>
+                <query_not_found_http_code_get>400</query_not_found_http_code_get>
+                <query_not_found_http_code_post>500</query_not_found_http_code_post>
+                <invalid_sha_http_code_get>400</invalid_sha_http_code_get>
+                <invalid_sha_http_code_post>500</invalid_sha_http_code_post>
+            </general>
+        </apq>
+    </default>
+</config>


### PR DESCRIPTION
Following #11, this is the PR to be able to override the default HTTP codes returned when query is missing or SHA doesn't match.